### PR TITLE
Show canceled candies

### DIFF
--- a/apps/nouns-camp/src/components/browse-screen.js
+++ b/apps/nouns-camp/src/components/browse-screen.js
@@ -880,28 +880,26 @@ const BrowseScreen = () => {
                             />
                           )}
 
-                        <SectionedList
-                          css={css({
-                            marginTop: allInactiveCandidatesShown
-                              ? "1.6rem"
-                              : "inherit",
-                            "@media(min-width: 600px)": {
-                              marginTop: allInactiveCandidatesShown
-                                ? "2.8rem"
-                                : "inherit",
-                            },
-                          })}
-                          showPlaceholder={!hasFetchedOnce}
-                          sections={["candidates:canceled"]
-                            .map(
-                              (sectionName) =>
-                                sectionsByName[sectionName] ?? {},
-                            )
-                            .filter(
-                              ({ items }) =>
-                                items != null && items.length !== 0,
-                            )}
-                        />
+                        {allInactiveCandidatesShown && (
+                          <SectionedList
+                            css={css({
+                              marginTop: "1.6rem",
+                              "@media(min-width: 600px)": {
+                                marginTop: "2.8rem",
+                              },
+                            })}
+                            showPlaceholder={!hasFetchedOnce}
+                            sections={["candidates:canceled"]
+                              .map(
+                                (sectionName) =>
+                                  sectionsByName[sectionName] ?? {},
+                              )
+                              .filter(
+                                ({ items }) =>
+                                  items != null && items.length !== 0,
+                              )}
+                          />
+                        )}
                       </div>
                     </Tabs.Item>
                     <Tabs.Item key="drafts" title="My drafts">

--- a/apps/nouns-camp/src/components/browse-screen.js
+++ b/apps/nouns-camp/src/components/browse-screen.js
@@ -126,6 +126,9 @@ const groupConfigByKey = {
     title: "Stale",
     description: `No activity within the last ${CANDIDATE_ACTIVE_THRESHOLD_IN_DAYS} days`,
   },
+  "candidates:canceled": {
+    title: "Canceled",
+  },
 };
 
 let hasFetchedBrowseDataOnce = false;
@@ -147,7 +150,7 @@ const BrowseScreen = () => {
 
   const proposals = useProposals({ state: true });
   const candidates = useProposalCandidates({
-    includeCanceled: false,
+    includeCanceled: true,
     includePromoted: false,
     includeProposalUpdates: false,
   });
@@ -343,6 +346,8 @@ const BrowseScreen = () => {
           (p) => p.createdTimestamp > candidateActiveThreshold,
         ));
 
+    const isCanceled = c.canceledTimestamp != null;
+
     if (!isActive) return "candidates:inactive";
 
     if (candidateSortStrategy === "popularity") return "candidates:popular";
@@ -375,6 +380,8 @@ const BrowseScreen = () => {
       return "candidates:sponsored";
 
     if (c.createdTimestamp >= candidateNewThreshold) return "candidates:new";
+
+    if (isCanceled) return "candidates:canceled";
 
     return "candidates:recently-active";
   };
@@ -456,7 +463,8 @@ const BrowseScreen = () => {
         case "candidates:popular":
         case "candidates:authored-proposal-update":
         case "candidates:inactive":
-        case "proposals:sponsored-proposal-update-awaiting-signature": {
+        case "proposals:sponsored-proposal-update-awaiting-signature":
+        case "candidates:canceled": {
           const sortedItems = isSearch
             ? items
             : arrayUtils.sortBy(
@@ -846,6 +854,7 @@ const BrowseScreen = () => {
                             "candidates:new",
                             "candidates:recently-active",
                             "candidates:popular",
+                            "candidates:canceled",
                             "candidates:inactive",
                           ]
                             .map(

--- a/apps/nouns-camp/src/components/browse-screen.js
+++ b/apps/nouns-camp/src/components/browse-screen.js
@@ -348,6 +348,7 @@ const BrowseScreen = () => {
 
     const isCanceled = c.canceledTimestamp != null;
 
+    if (isCanceled) return "candidates:canceled";
     if (!isActive) return "candidates:inactive";
 
     if (candidateSortStrategy === "popularity") return "candidates:popular";
@@ -380,8 +381,6 @@ const BrowseScreen = () => {
       return "candidates:sponsored";
 
     if (c.createdTimestamp >= candidateNewThreshold) return "candidates:new";
-
-    if (isCanceled) return "candidates:canceled";
 
     return "candidates:recently-active";
   };
@@ -550,6 +549,12 @@ const BrowseScreen = () => {
       { replace: true },
     );
   });
+
+  const allInactiveCandidatesShown =
+    page == null ||
+    (sectionsByName["candidates:inactive"] != null &&
+      BROWSE_LIST_PAGE_ITEM_COUNT * page >
+        sectionsByName["candidates:inactive"].count);
 
   return (
     <>
@@ -854,7 +859,6 @@ const BrowseScreen = () => {
                             "candidates:new",
                             "candidates:recently-active",
                             "candidates:popular",
-                            "candidates:canceled",
                             "candidates:inactive",
                           ]
                             .map(
@@ -875,6 +879,29 @@ const BrowseScreen = () => {
                               showAll={() => setPage(null)}
                             />
                           )}
+
+                        <SectionedList
+                          css={css({
+                            marginTop: allInactiveCandidatesShown
+                              ? "1.6rem"
+                              : "inherit",
+                            "@media(min-width: 600px)": {
+                              marginTop: allInactiveCandidatesShown
+                                ? "2.8rem"
+                                : "inherit",
+                            },
+                          })}
+                          showPlaceholder={!hasFetchedOnce}
+                          sections={["candidates:canceled"]
+                            .map(
+                              (sectionName) =>
+                                sectionsByName[sectionName] ?? {},
+                            )
+                            .filter(
+                              ({ items }) =>
+                                items != null && items.length !== 0,
+                            )}
+                        />
                       </div>
                     </Tabs.Item>
                     <Tabs.Item key="drafts" title="My drafts">


### PR DESCRIPTION
I added the canceled candies below the inactive ones, despite the latter having pagination. The reason was that today there are very few canceled candies (15) so we don't need to paginate those, and having 2 pages would increase the complexity unnecessarily. If you have a better UX suggestion for this lmk, but it can also be handled in a diff PR.

With that in mind, I just added a new sectioned list below the inactive and some logic to handle margins when all inactive candies are shown and there's no pagination component.

<img width="864" alt="Screenshot 2024-04-11 at 11 34 51" src="https://github.com/obvious-inc/frontend-monorepo/assets/314617/9af1a469-e844-40fd-a626-695e423bae45">
<img width="878" alt="Screenshot 2024-04-11 at 11 35 02" src="https://github.com/obvious-inc/frontend-monorepo/assets/314617/d6172169-ee1d-424b-835c-c49ca59782c8">
