### PR TITLE
Update candidates screen 'parent' breadcrumb to link to /candidates to be consistent with the proposals screen

### DIFF
--- a/apps/nouns-camp/src/components/proposal-candidate-screen.js
+++ b/apps/nouns-camp/src/components/proposal-candidate-screen.js
@@ -1380,7 +1380,7 @@ const ProposalCandidateScreen = ({ candidateId: rawId }) => {
       <Layout
         scrollContainerRef={scrollContainerRef}
         navigationStack={[
-          { to: "/?tab=candidates", label: "Candidates", desktopOnly: true },
+          { to: "/candidates", label: "Candidates", desktopOnly: true },
           {
             to: `/candidates/${encodeURIComponent(candidateId)}`,
             label: (


### PR DESCRIPTION
I browse proposals and candidates in 'full screen mode' most of the time (/proposals and /candidates), and when I do I always use the breacrumbs/header nav to go back to the list screen from a detail page. The behavior on /candidates is different from /proposals which always confuses me, so this PR changes that!