### PR TITLE
Hide candidate page sponsorStatusCallout if candidate has been promoted

### DIFF
--- a/apps/nouns-camp/src/components/proposal-candidate-screen.js
+++ b/apps/nouns-camp/src/components/proposal-candidate-screen.js
@@ -164,6 +164,7 @@ const ProposalCandidateScreenContent = ({
     connectedWalletAccountAddress != null &&
     candidate.proposerId.toLowerCase() === connectedWalletAccountAddress;
   const isProposalUpdate = candidate.latestVersion.targetProposalId != null;
+  const hasBeenPromoted = candidate.latestVersion.proposalId != null;
 
   const proposerDelegateNounIds =
     proposerDelegate?.nounsRepresented.map((n) => n.id) ?? [];
@@ -343,9 +344,11 @@ const ProposalCandidateScreenContent = ({
                     </span>
                   </div>
 
-                  <div style={{ margin: "0 0 4.8rem" }}>
-                    {sponsorStatusCallout}
-                  </div>
+                  {!hasBeenPromoted && (
+                    <div style={{ margin: "0 0 4.8rem" }}>
+                      {sponsorStatusCallout}
+                    </div>
+                  )}
 
                   {feedbackVoteCountExcludingAbstained > 0 && (
                     <div style={{ marginBottom: "4rem" }}>
@@ -456,7 +459,7 @@ const ProposalCandidateScreenContent = ({
               </p>
             </Callout>
           )}
-          {candidate.latestVersion.proposalId != null ? (
+          {hasBeenPromoted ? (
             <Callout
               compact
               variant="info"
@@ -732,9 +735,11 @@ const ProposalCandidateScreenContent = ({
                             controlled by proposer
                           </Callout>
                         )}
-                        <div style={{ margin: "0 0 3.2rem" }}>
-                          {sponsorStatusCallout}
-                        </div>
+                        {!hasBeenPromoted && (
+                          <div style={{ margin: "0 0 3.2rem" }}>
+                            {sponsorStatusCallout}
+                          </div>
+                        )}
                         <SponsorsTabMainContent
                           candidateId={candidateId}
                           toggleSponsorDialog={toggleSponsorDialog}


### PR DESCRIPTION
Hides the sponsorStatusCallout from the candidate page if the candidate has been promoted to a proposal, to avoid confusing/conflicting info in the header (has been promoted / needs more sponsors to be promoted)


Before
![image](https://github.com/user-attachments/assets/d4cd8865-d5f5-4168-b9cf-c433fa08f400)


After
![image](https://github.com/user-attachments/assets/5d54c279-9359-4e02-8cb5-dde5855cf763)
