### PR TITLE
Small treasury dialog styling improvement: update timerange filters to be right aligned

### DIFF
--- a/apps/nouns-camp/src/components/treasury-dialog.js
+++ b/apps/nouns-camp/src/components/treasury-dialog.js
@@ -822,6 +822,9 @@ const Heading = (props) => (
         color: t.colors.textDimmed,
         margin: "0 0 1rem",
         "* + &": { marginTop: "2.8rem" },
+        justifyContent: "space-between",
+        display: "flex",
+        alignItems: "center",
       })
     }
     {...props}


### PR DESCRIPTION
At first I didn't realize that they were select-controls, I though they were just labels. This makes it clearer that they are clickable imo

![image](https://github.com/user-attachments/assets/8dffdaad-a4a2-4a42-ba4c-115e79a76dc9)
