### PR TITLE
Small treasury dialog styling improvements, make time range select filter clearer

### DIFF
--- a/apps/nouns-camp/src/components/treasury-dialog.js
+++ b/apps/nouns-camp/src/components/treasury-dialog.js
@@ -457,7 +457,8 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
         <Heading>
           Activity
           <Select
-            size="small"
+            size="tiny"
+            variant="tag"
             aria-label="Activity day count"
             value={activityDayCount}
             options={[7, 14, 30, 60, 90, 365].map((count) => ({
@@ -469,23 +470,10 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
             }}
             fullWidth={false}
             width="max-content"
-            renderTriggerContent={(value) => {
-              return (
-                <>
-                  Last:{" "}
-                  <em
-                    css={(t) =>
-                      css({
-                        fontStyle: "normal",
-                        fontWeight: t.text.weights.emphasis,
-                      })
-                    }
-                  >
-                    {value} days
-                  </em>
-                </>
-              );
+            buttonProps={{
+              style: { color: "inherit", margin: "-0.1rem 0.5em" },
             }}
+            renderTriggerContent={(value) => <>Last {value} days</>}
           />
         </Heading>
         <Dl>
@@ -614,7 +602,8 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
         <Heading>
           Inflow projection
           <Select
-            size="small"
+            size="tiny"
+            variant="tag"
             aria-label="Inflow projection day count"
             value={inflowProjectionDayCount}
             options={[
@@ -627,27 +616,16 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
             }}
             fullWidth={false}
             width="max-content"
+            buttonProps={{
+              style: { color: "inherit", margin: "-0.1rem 0.5em" },
+            }}
             renderTriggerContent={(value) => {
               const filterLabel = {
                 30: "1 month",
                 180: "6 months",
                 365: "1 year",
               }[value];
-              return (
-                <>
-                  For:{" "}
-                  <em
-                    css={(t) =>
-                      css({
-                        fontStyle: "normal",
-                        fontWeight: t.text.weights.emphasis,
-                      })
-                    }
-                  >
-                    {filterLabel}
-                  </em>
-                </>
-              );
+              return <>For {filterLabel}</>;
             }}
           />
         </Heading>
@@ -849,9 +827,6 @@ const Heading = (props) => (
         color: t.colors.textDimmed,
         margin: "0 0 1rem",
         "* + &": { marginTop: "2.8rem" },
-        justifyContent: "space-between",
-        display: "flex",
-        alignItems: "center",
       })
     }
     {...props}

--- a/apps/nouns-camp/src/components/treasury-dialog.js
+++ b/apps/nouns-camp/src/components/treasury-dialog.js
@@ -6,6 +6,7 @@ import Dialog from "@shades/ui-web/dialog";
 import DialogHeader from "@shades/ui-web/dialog-header";
 import Spinner from "@shades/ui-web/spinner";
 import * as Tooltip from "@shades/ui-web/tooltip";
+import Select from "@shades/ui-web/select";
 import { resolveIdentifier as resolveContractIdentifier } from "../contracts.js";
 import {
   parse as parseTransactions,
@@ -17,7 +18,6 @@ import { useSearchParams } from "../hooks/navigation.js";
 import useTreasuryData from "../hooks/treasury-data.js";
 import useRecentAuctionProceeds from "../hooks/recent-auction-proceeds.js";
 import { FormattedEthWithConditionalTooltip } from "./transaction-list.js";
-import NativeSelect from "./native-select.js";
 import FormattedNumber from "./formatted-number.js";
 import ExplorerAddressLink from "./chain-explorer-address-link.js";
 import Link from "@shades/ui-web/link";
@@ -455,25 +455,36 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
           ))}
         </Dl>
         <Heading>
-          Activity last{" "}
-          <NativeSelect
+          Activity
+          <Select
+            size="small"
+            aria-label="Activity day count"
             value={activityDayCount}
             options={[7, 14, 30, 60, 90, 365].map((count) => ({
               value: count,
               label: `${count} days`,
             }))}
-            css={(t) =>
-              css({
-                display: "inline-block",
-                border: "0.1rem solid",
-                borderColor: t.colors.borderLighter,
-                borderRadius: "0.3rem",
-                padding: "0 0.4rem",
-                margin: "0 0.1em",
-              })
-            }
-            onChange={(e) => {
-              setActivityDayCount(e.target.value);
+            onChange={(value) => {
+              setActivityDayCount(value);
+            }}
+            fullWidth={false}
+            width="max-content"
+            renderTriggerContent={(value) => {
+              return (
+                <>
+                  Last:{" "}
+                  <em
+                    css={(t) =>
+                      css({
+                        fontStyle: "normal",
+                        fontWeight: t.text.weights.emphasis,
+                      })
+                    }
+                  >
+                    {value} days
+                  </em>
+                </>
+              );
             }}
           />
         </Heading>
@@ -601,26 +612,42 @@ const Content = ({ balances, rates, aprs, totals, titleProps, dismiss }) => {
           </dd>
         </Dl>
         <Heading>
-          Inflow projection for{" "}
-          <NativeSelect
+          Inflow projection
+          <Select
+            size="small"
+            aria-label="Inflow projection day count"
             value={inflowProjectionDayCount}
             options={[
               { value: 30, label: "1 month" },
               { value: 180, label: "6 months" },
               { value: 365, label: "1 year" },
             ]}
-            css={(t) =>
-              css({
-                display: "inline-block",
-                border: "0.1rem solid",
-                borderColor: t.colors.borderLighter,
-                borderRadius: "0.3rem",
-                padding: "0 0.4rem",
-                margin: "0 0.1em",
-              })
-            }
-            onChange={(e) => {
-              setInflowProjectionDayCount(Number(e.target.value));
+            onChange={(value) => {
+              setInflowProjectionDayCount(value);
+            }}
+            fullWidth={false}
+            width="max-content"
+            renderTriggerContent={(value) => {
+              const filterLabel = {
+                30: "1 month",
+                180: "6 months",
+                365: "1 year",
+              }[value];
+              return (
+                <>
+                  For:{" "}
+                  <em
+                    css={(t) =>
+                      css({
+                        fontStyle: "normal",
+                        fontWeight: t.text.weights.emphasis,
+                      })
+                    }
+                  >
+                    {filterLabel}
+                  </em>
+                </>
+              );
             }}
           />
         </Heading>

--- a/apps/nouns-camp/src/components/treasury-dialog.js
+++ b/apps/nouns-camp/src/components/treasury-dialog.js
@@ -849,6 +849,9 @@ const Heading = (props) => (
         color: t.colors.textDimmed,
         margin: "0 0 1rem",
         "* + &": { marginTop: "2.8rem" },
+        justifyContent: "space-between",
+        display: "flex",
+        alignItems: "center",
       })
     }
     {...props}

--- a/packages/ui-web/src/button.js
+++ b/packages/ui-web/src/button.js
@@ -26,8 +26,8 @@ const baseStyles = (t, { align }) => ({
 
 const textDangerHoverModifier = "rgb(235 87 87 / 10%)";
 
-const stylesByVariant = (t, { danger }) => ({
-  default: {
+const stylesByVariant = (t, { danger }) => {
+  const defaultStyles = {
     color: danger ? t.colors.textDanger : t.colors.textNormal,
     border: "1px solid",
     borderColor: danger ? t.colors.borderDanger : t.colors.borderLight,
@@ -38,42 +38,50 @@ const stylesByVariant = (t, { danger }) => ({
           : t.colors.backgroundModifierNormal,
       },
     },
-  },
-  opaque: {
-    color: t.colors.textNormal,
-    background: t.colors.backgroundModifierNormal,
-    "@media (hover: hover)": {
-      "&:not([disabled]):hover": {
-        color: t.colors.textAccent,
+  };
+  return {
+    default: defaultStyles,
+    opaque: {
+      color: t.colors.textNormal,
+      background: t.colors.backgroundModifierNormal,
+      "@media (hover: hover)": {
+        "&:not([disabled]):hover": {
+          color: t.colors.textAccent,
+        },
       },
     },
-  },
-  transparent: {
-    color: danger ? t.colors.textDanger : t.colors.textNormal,
-    background: "none",
-    "@media (hover: hover)": {
-      "&:not([disabled]):hover": {
-        color: danger ? t.colors.textDanger : t.colors.textAccent,
-        background: danger
-          ? textDangerHoverModifier
-          : t.colors.backgroundModifierNormal,
+    transparent: {
+      color: danger ? t.colors.textDanger : t.colors.textNormal,
+      background: "none",
+      "@media (hover: hover)": {
+        "&:not([disabled]):hover": {
+          color: danger ? t.colors.textDanger : t.colors.textAccent,
+          background: danger
+            ? textDangerHoverModifier
+            : t.colors.backgroundModifierNormal,
+        },
       },
     },
-  },
-  primary: {
-    color: "white",
-    background: t.colors.primary,
-    border: "1px solid transparent",
-    "&:focus-visible": {
-      boxShadow: `0 0 0 0.3rem ${t.colors.primaryTransparent}`,
-    },
-    "@media (hover: hover)": {
-      "&:not([disabled]):hover": {
-        background: t.colors.primaryModifierHover,
+    primary: {
+      color: "white",
+      background: t.colors.primary,
+      border: "1px solid transparent",
+      "&:focus-visible": {
+        boxShadow: `0 0 0 0.3rem ${t.colors.primaryTransparent}`,
+      },
+      "@media (hover: hover)": {
+        "&:not([disabled]):hover": {
+          background: t.colors.primaryModifierHover,
+        },
       },
     },
-  },
-});
+    tag: {
+      ...defaultStyles,
+      textTransform: "uppercase",
+      fontWeight: t.text.weights.emphasis,
+    },
+  };
+};
 
 export const heightBySize = {
   default: "3.2rem",


### PR DESCRIPTION
At first I didn't realize that I could change time range for the activity and inflow projection sections, I thought they were just labels and not select controls. This makes it much clearer that they are clickable imo!

![image](https://github.com/user-attachments/assets/8a84f775-0c04-4d5d-82ef-f47268f32dd6)
