### PR TITLE
Add simple voter search result to the landing-screen search

### DIFF
--- a/apps/nouns-camp/src/components/landing-screen.js
+++ b/apps/nouns-camp/src/components/landing-screen.js
@@ -2,7 +2,8 @@
 
 import dateSubtractDays from "date-fns/subDays";
 import dateStartOfDay from "date-fns/startOfDay";
-import { formatEther } from "viem";
+import { formatEther, isAddress, getAddress as checksumEncodeAddress } from "viem";
+import { normalize as normalizeEns } from 'viem/ens'
 import React from "react";
 import NextLink from "next/link";
 import { css } from "@emotion/react";
@@ -12,6 +13,7 @@ import { useCachedState } from "@shades/common/app";
 import {
   array as arrayUtils,
   object as objectUtils,
+  ethereum as ethereumUtils,
   searchRecords,
 } from "@shades/common/utils";
 import Input from "@shades/ui-web/input";
@@ -866,6 +868,9 @@ const BrowseScreen = () => {
               {deferredQuery !== "" ? (
                 // Search results
                 <div css={css({ marginTop: "2rem" })}>
+                  <div css={css({ marginBottom: "1rem" })}>
+                    <VoterSearchResult query={deferredQuery} />
+                  </div>
                   <ProposalList
                     items={
                       page == null
@@ -903,6 +908,39 @@ const BrowseScreen = () => {
         </div>
       </Layout>
     </>
+  );
+};
+
+const safeNormalizeEns = (input) => {
+  try {
+    return normalizeEns(input);
+  } catch (_) {}
+};
+
+const VoterSearchResult = ({ query }) => {
+  const normalizedEns = safeNormalizeEns(query);
+
+  if (!isAddress(query) && !normalizedEns?.endsWith(".eth")) return;
+
+  let voter = "";
+  let voterDisplay = "";
+  if (normalizedEns?.endsWith(".eth")) {
+    voter = normalizedEns;
+    voterDisplay = normalizedEns;
+  } else {
+    voter = checksumEncodeAddress(query);
+    voterDisplay = ethereumUtils.truncateAddress(voter);
+  }
+
+  return (
+    <Button
+      size="default"
+      component={NextLink}
+      prefetch
+      href={`/voters/${voter}`}
+    >
+      View {voterDisplay} voter profile
+    </Button>
   );
 };
 


### PR DESCRIPTION
Right now there's no easy way to get to a voter profile unless the voter has created or sponsored a candidate/prop, you need to know that you should go to the Voters tab on the right -> click the small Fullscreen button -> and then search. This PR adds a simple "Go to <addy.eth>  voter profile" to the landing page search if the input is an .eth address or a full 0x-address.

Example, instead of just showing nothing when I search for `bonfireguild.eth` it shows a button:
![image](https://github.com/user-attachments/assets/2a42311e-ceef-480b-aa7c-e8f1b2d43b9a)
