### PR TITLE
Improve price shown for noun purchases in the activity feed for bulk buy transactions

### DIFF
--- a/apps/nouns-camp/src/components/activity-feed.js
+++ b/apps/nouns-camp/src/components/activity-feed.js
@@ -297,9 +297,13 @@ const FeedItem = React.memo(
       enabled: isOnScreen,
     });
 
-    const nounTransferMeta = useNounTransferMeta(item.transactionHash, {
-      enabled: item.type === "noun-transfer",
-    });
+    const nounTransferMeta = useNounTransferMeta(
+      item.transactionHash,
+      item.nounId,
+      {
+        enabled: item.type === "noun-transfer",
+      },
+    );
 
     const authorReplyCasts = (() => {
       if (replyCasts == null) return null;
@@ -1460,7 +1464,7 @@ const ItemTitle = ({ item, context }) => {
 };
 
 const NounTransferItem = ({ item }) => {
-  const transferMeta = useNounTransferMeta(item.transactionHash);
+  const transferMeta = useNounTransferMeta(item.transactionHash, item.nounId);
 
   if (transferMeta == null) return null; // Loading
 

--- a/apps/nouns-camp/src/hooks/noun-transfers.js
+++ b/apps/nouns-camp/src/hooks/noun-transfers.js
@@ -23,14 +23,14 @@ const decodeEventLogs = ({ logs, abi }) => {
   return decodedEventLogs;
 };
 
-const decodeNounTransferEvent = (transactionReceipt) => {
+const decodeNounTransferEvents = (transactionReceipt) => {
   const { address: nounTokenAddress } = resolveContractIdentifier("token");
 
   const logs = transactionReceipt.logs.filter(
     (l) => l.address.toLowerCase() === nounTokenAddress,
   );
 
-  const decodedLogs = decodeEventLogs({
+  return decodeEventLogs({
     logs,
     abi: [
       {
@@ -44,8 +44,6 @@ const decodeNounTransferEvent = (transactionReceipt) => {
       },
     ],
   });
-
-  return decodedLogs[0];
 };
 
 const decodeForkEvents = (transactionReceipt) => {
@@ -119,7 +117,11 @@ const decodeEthTransferEventLogs = (transactionReceipt) => {
   });
 };
 
-export const useTransferMeta = (transactionHash, { enabled = true } = {}) => {
+export const useTransferMeta = (
+  transactionHash,
+  nounId,
+  { enabled = true } = {},
+) => {
   const { data: transaction } = useTransaction({
     hash: transactionHash,
     query: {
@@ -163,7 +165,10 @@ export const useTransferMeta = (transactionHash, { enabled = true } = {}) => {
       }
     }
 
-    const nounTransferEvent = decodeNounTransferEvent(receipt);
+    const transferEvents = decodeNounTransferEvents(receipt);
+    const nounTransferEvent = transferEvents.find(
+      ({ args }) => args.tokenId === BigInt(nounId),
+    );
     const ethTransferLogs = decodeEthTransferEventLogs(receipt);
 
     const { to: receiverAccount } = nounTransferEvent.args;


### PR DESCRIPTION
Updates the feed to use the average sale price for bulk buy transactions that aren't groupd in the feed.

Before
![image](https://github.com/user-attachments/assets/2268523b-214b-46d0-915c-d61079e54d21)

After
![image](https://github.com/user-attachments/assets/34c5c5f5-44fc-4211-8a0f-96d0bc548625)

These should ideally be grouped together I think? But that requires quite a lot work since all items are assumed to have one from account and one to account.