### PR TITLE
feat(camp): add underline support using <ins>

### DIFF
--- a/packages/common/src/utils/markdown.js
+++ b/packages/common/src/utils/markdown.js
@@ -262,6 +262,9 @@ const parseToken = (token, context = {}) => {
     case "em":
       return parseChildren(token, parseToken, { ...context, italic: true });
 
+    case "ins":
+      return parseChildren(token, parseToken, { ...context, underline: true });
+
     case "br":
       return { type: "text", text: "\n" };
 
@@ -284,6 +287,7 @@ const parseToken = (token, context = {}) => {
       if (context?.bold) el.bold = true;
       if (context?.italic) el.italic = true;
       if (context?.strikethrough) el.strikethrough = true;
+      if (context?.underline) el.underline = true;
       return el;
     }
 
@@ -302,6 +306,31 @@ const parseToken = (token, context = {}) => {
       throw new Error(`Unknown token "${token.type}"`);
   }
 };
+
+// https://www.markdownguide.org/hacks/#underline
+const insExtension = {
+  name: "ins",
+  level: "inline",
+  start(src) {
+    return src.indexOf("<ins>");
+  },
+  tokenizer(src) {
+    const match = src.match(/^<ins>(.*?)<\/ins>/);
+
+    if (match) {
+      return {
+        type: "ins",
+        raw: match[0],
+        text: match[1],
+        tokens: [{ type: "text", raw: match[1], text: match[1] }],
+      };
+    }
+
+    return;
+  },
+};
+
+marked.use({ extensions: [insExtension] });
 
 export const toMessageBlocks = (text, { displayImages = true } = {}) => {
   const tokens = marked.lexer(text);

--- a/packages/common/src/utils/message.js
+++ b/packages/common/src/utils/message.js
@@ -101,7 +101,7 @@ export const isEqual = (ns1, ns2, options = {}) => {
   // Text nodes
   if (n1.text != null)
     return ["text", "bold", "italic", "strikethrough", "underline"].every(
-      (p) => n1[p] === n2[p]
+      (p) => n1[p] === n2[p],
     );
 
   // The rest is for element nodes

--- a/packages/common/src/utils/message.js
+++ b/packages/common/src/utils/message.js
@@ -100,8 +100,8 @@ export const isEqual = (ns1, ns2, options = {}) => {
 
   // Text nodes
   if (n1.text != null)
-    return ["text", "bold", "italic", "strikethrough"].every(
-      (p) => n1[p] === n2[p],
+    return ["text", "bold", "italic", "strikethrough", "underline"].every(
+      (p) => n1[p] === n2[p]
     );
 
   // The rest is for element nodes
@@ -212,6 +212,7 @@ export const stringifyBlocks = (
     if (l.bold) text = `*${text}*`;
     if (l.italic) text = `_${text}_`;
     if (l.strikethrough) text = `~${text}~`;
+    if (l.underline) text = `<ins>${text}</ins>`;
     return text;
   };
 
@@ -333,6 +334,7 @@ export const toMarkdown = (blockElements) => {
       let isBold = false;
       let isItalic = false;
       let isStrikethrough = false;
+      let isUnderline = false;
 
       for (const [index, node] of el.children.entries()) {
         const isLast = index === el.children.length - 1;
@@ -361,6 +363,11 @@ export const toMarkdown = (blockElements) => {
           children += "**";
           isBold = true;
         }
+        if (!isUnderline && node.underline) {
+          // Start underline
+          children += "<ins>";
+          isUnderline = true;
+        }
 
         children += renderedNode.trim();
 
@@ -378,6 +385,12 @@ export const toMarkdown = (blockElements) => {
           // End strikethrough
           children += "~~";
           isStrikethrough = false;
+        }
+
+        if (isUnderline && (isLast || !nextNode.underline)) {
+          // End underline
+          children += "</ins>";
+          isUnderline = false;
         }
 
         children += "".padStart(trailingSpaces, " ");

--- a/packages/ui-web/src/rich-text-editor.js
+++ b/packages/ui-web/src/rich-text-editor.js
@@ -759,6 +759,11 @@ const Leaf = ({ attributes, children, leaf }) => {
   if (leaf.bold) children = <strong>{children}</strong>;
   if (leaf.italic) children = <em>{children}</em>;
   if (leaf.strikethrough) children = <s>{children}</s>;
+  if (leaf.underline) {
+    children = (
+      <span css={css({ textDecoration: "underline" })}>{children}</span>
+    );
+  }
 
   return <span {...attributes}>{children}</span>;
 };
@@ -877,6 +882,13 @@ const toolbarActionsByKey = {
     mark: "strikethrough",
     props: {
       style: { textDecoration: "line-through" },
+    },
+  },
+  "toggle-mark-underline": {
+    icon: "U",
+    mark: "underline",
+    props: {
+      style: { textDecoration: "underline" },
     },
   },
   "insert-link": {
@@ -1131,6 +1143,7 @@ export const Toolbar = ({ disabled: disabled_, onFocus, onBlur, ...props }) => {
       case "toggle-mark-bold":
       case "toggle-mark-italic":
       case "toggle-mark-strikethrough":
+      case "toggle-mark-underline":
         return (
           <button
             key={action.key}
@@ -1240,7 +1253,12 @@ export const Toolbar = ({ disabled: disabled_, onFocus, onBlur, ...props }) => {
         !isTouchDevice() && selectedNodeIsTransformable
           ? ["block-transform"]
           : null,
-        ["toggle-mark-bold", "toggle-mark-italic", "toggle-mark-strikethrough"],
+        [
+          "toggle-mark-bold",
+          "toggle-mark-italic",
+          "toggle-mark-strikethrough",
+          "toggle-mark-underline",
+        ],
         isTouchDevice()
           ? ["heading-transform", "quote-transform", "code-block-transform"]
           : null,

--- a/packages/ui-web/src/rich-text-editor.js
+++ b/packages/ui-web/src/rich-text-editor.js
@@ -62,6 +62,7 @@ const markHotkeys = {
   "mod+b": "bold",
   "mod+i": "italic",
   "mod+shift+x": "strikethrough",
+  "mod+u": "underline",
 };
 
 const Context = React.createContext();
@@ -1143,7 +1144,6 @@ export const Toolbar = ({ disabled: disabled_, onFocus, onBlur, ...props }) => {
       case "toggle-mark-bold":
       case "toggle-mark-italic":
       case "toggle-mark-strikethrough":
-      case "toggle-mark-underline":
         return (
           <button
             key={action.key}
@@ -1253,12 +1253,7 @@ export const Toolbar = ({ disabled: disabled_, onFocus, onBlur, ...props }) => {
         !isTouchDevice() && selectedNodeIsTransformable
           ? ["block-transform"]
           : null,
-        [
-          "toggle-mark-bold",
-          "toggle-mark-italic",
-          "toggle-mark-strikethrough",
-          "toggle-mark-underline",
-        ],
+        ["toggle-mark-bold", "toggle-mark-italic", "toggle-mark-strikethrough"],
         isTouchDevice()
           ? ["heading-transform", "quote-transform", "code-block-transform"]
           : null,

--- a/packages/ui-web/src/rich-text-editor.js
+++ b/packages/ui-web/src/rich-text-editor.js
@@ -761,9 +761,7 @@ const Leaf = ({ attributes, children, leaf }) => {
   if (leaf.italic) children = <em>{children}</em>;
   if (leaf.strikethrough) children = <s>{children}</s>;
   if (leaf.underline) {
-    children = (
-      <span css={css({ textDecoration: "underline" })}>{children}</span>
-    );
+    children = <span className="underline">{children}</span>;
   }
 
   return <span {...attributes}>{children}</span>;

--- a/packages/ui-web/src/rich-text.js
+++ b/packages/ui-web/src/rich-text.js
@@ -248,6 +248,10 @@ export const createCss = (t) => ({
   em: { fontStyle: "italic" },
   strong: { fontWeight: t.text.weights.emphasis },
 
+  ".underline": {
+    textDecoration: "underline",
+  },
+
   // Inline mode
   '&[data-inline="true"]': {
     // All block elements
@@ -309,7 +313,7 @@ const renderLeaf = (l, i) => {
   if (l.strikethrough) children = <s key={i}>{children}</s>;
   if (l.underline)
     children = (
-      <span key={i} css={css({ textDecoration: "underline" })}>
+      <span key={i} className="underline">
         {children}
       </span>
     );

--- a/packages/ui-web/src/rich-text.js
+++ b/packages/ui-web/src/rich-text.js
@@ -307,6 +307,12 @@ const renderLeaf = (l, i) => {
   if (l.bold) children = <strong key={i}>{children}</strong>;
   if (l.italic) children = <em key={i}>{children}</em>;
   if (l.strikethrough) children = <s key={i}>{children}</s>;
+  if (l.underline)
+    children = (
+      <span key={i} css={css({ textDecoration: "underline" })}>
+        {children}
+      </span>
+    );
   return <React.Fragment key={i}>{children}</React.Fragment>;
 };
 

--- a/packages/ui-web/src/slate/plugins/headings.js
+++ b/packages/ui-web/src/slate/plugins/headings.js
@@ -63,8 +63,13 @@ const middleware = (editor) => {
       }
 
       // No marks
-      if (childNode.italic || childNode.bold || childNode.strikethrough) {
-        editor.unsetNodes(["italic", "bold", "strikethrough"], {
+      if (
+        childNode.italic ||
+        childNode.bold ||
+        childNode.strikethrough ||
+        childNode.underline
+      ) {
+        editor.unsetNodes(["italic", "bold", "strikethrough", "underline"], {
           at: childPath,
         });
         return;

--- a/packages/ui-web/src/slate/utils.js
+++ b/packages/ui-web/src/slate/utils.js
@@ -81,6 +81,7 @@ export const toMessageBlocks = (nodes) => {
         italic: n.children[0]?.italic,
         bold: n.children[0]?.bold,
         strikethrough: n.children[0]?.strikethrough,
+        underline: n.children[0]?.underline,
       };
     if (n.type === "emoji")
       return {


### PR DESCRIPTION
Using the `<ins>` as described [here](https://www.markdownguide.org/hacks/#underline) seems to be an <ins>accepted way</ins> of doing underlines in markdown for papers/reports. 

Added support for rendering those elements as underlined text, and also the ability to underline things using shortcut cmd/ctrl + u