### PR TITLE
Allow inline images on camp

### DIFF
--- a/apps/nouns-camp/src/components/proposal-screen.jsx
+++ b/apps/nouns-camp/src/components/proposal-screen.jsx
@@ -1551,9 +1551,9 @@ export const ProposalBody = React.memo(({ markdownText, ...props }) => {
                 ".image > img": {
                   background: "unset",
                 },
-                ".image[data-inline=\"true\"]": {
+                '.image[data-inline="true"]': {
                   display: "inline-block",
-                  margin: 0
+                  margin: 0,
                 },
               })}
             />

--- a/apps/nouns-camp/src/components/proposal-screen.jsx
+++ b/apps/nouns-camp/src/components/proposal-screen.jsx
@@ -1551,6 +1551,10 @@ export const ProposalBody = React.memo(({ markdownText, ...props }) => {
                 ".image > img": {
                   background: "unset",
                 },
+                ".image[data-inline=\"true\"]": {
+                  display: "inline-block",
+                  margin: 0
+                },
               })}
             />
           </React.Suspense>


### PR DESCRIPTION
For consistency with nouns.wtf:

nouns.wtf prop:
![CleanShot 2025-03-21 at 17 29 05@2x](https://github.com/user-attachments/assets/2bb2f185-07b9-4d2a-a0ab-dd463fb9f98b)

nouns.camp (current):
![CleanShot 2025-03-21 at 17 29 56](https://github.com/user-attachments/assets/cb8051e4-8af9-49a1-8463-9001c0c5e5af)

nouns.camp (proposed):
![CleanShot 2025-03-21 at 17 30 23@2x](https://github.com/user-attachments/assets/e164f4a3-79cb-4642-baad-77a112a04ad3)

(looks great on mobile:D)
![CleanShot 2025-03-21 at 17 31 15@2x](https://github.com/user-attachments/assets/f934a0e6-4980-4388-ad21-8b57141ad4cd)

