### PR TITLE
Allow clicking on logo to refresh home to default state

### DIFF
--- a/apps/nouns-camp/src/components/landing-screen.jsx
+++ b/apps/nouns-camp/src/components/landing-screen.jsx
@@ -270,10 +270,13 @@ const BrowseScreen = () => {
 
   const query = searchParams.get("q") ?? "";
   const deferredQuery = React.useDeferredValue(query.trim());
-  const [inputValue, setInputValue] = React.useState(query);
+  const inputRef = React.useRef();
 
+  // Update input value directly when query changes (like when navigating to home)
   React.useEffect(() => {
-    setInputValue(query);
+    if (inputRef.current && inputRef.current.value !== query) {
+      inputRef.current.value = query;
+    }
   }, [query]);
 
   const { address: connectedAccountAddress } = useWallet();
@@ -912,13 +915,12 @@ const BrowseScreen = () => {
                 }
               >
                 <Input
+                  ref={inputRef}
                   placeholder="Search..."
-                  value={inputValue}
+                  defaultValue={query}
                   size="large"
                   onChange={(e) => {
-                    const newValue = e.target.value;
-                    setInputValue(newValue);
-                    handleSearchInputChange(newValue);
+                    handleSearchInputChange(e.target.value);
                   }}
                 />
               </div>

--- a/apps/nouns-camp/src/components/landing-screen.jsx
+++ b/apps/nouns-camp/src/components/landing-screen.jsx
@@ -270,6 +270,11 @@ const BrowseScreen = () => {
 
   const query = searchParams.get("q") ?? "";
   const deferredQuery = React.useDeferredValue(query.trim());
+  const [inputValue, setInputValue] = React.useState(query);
+
+  React.useEffect(() => {
+    setInputValue(query);
+  }, [query]);
 
   const { address: connectedAccountAddress } = useWallet();
 
@@ -908,10 +913,12 @@ const BrowseScreen = () => {
               >
                 <Input
                   placeholder="Search..."
-                  defaultValue={query}
+                  value={inputValue}
                   size="large"
                   onChange={(e) => {
-                    handleSearchInputChange(e.target.value);
+                    const newValue = e.target.value;
+                    setInputValue(newValue);
+                    handleSearchInputChange(newValue);
                   }}
                 />
               </div>

--- a/apps/nouns-camp/src/components/layout.jsx
+++ b/apps/nouns-camp/src/components/layout.jsx
@@ -536,10 +536,9 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
 
             return {
               key: "root-logo",
-              component: "div",
+              to: "/",
               props: {
                 style: {
-                  pointerEvents: "none",
                   height: "2.8rem",
                   minWidth: "2.8rem",
                   paddingBlock: 0,

--- a/apps/nouns-camp/src/components/layout.jsx
+++ b/apps/nouns-camp/src/components/layout.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { css, keyframes } from "@emotion/react";
 import NextLink from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { invariant } from "@shades/common/utils";
 import { useMatchMedia } from "@shades/common/react";
 import Button from "@shades/ui-web/button";
@@ -319,6 +319,7 @@ const defaultActionIds = [
 
 const NavBar = ({ navigationStack, actions: customActions }) => {
   const unresolvedActions = customActions ?? defaultActionIds;
+  const searchParams = useSearchParams();
 
   const { open: openTreasuryDialog } = useDialog("treasury");
   const { open: openAccountDialog } = useDialog("account");
@@ -534,9 +535,16 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                 ),
               };
 
+            // Different behavior based on current location
+            const isRoot = pathname === "/";
+            // Check if there are any search parameters
+            const hasSearchParams = searchParams.size > 0;
+
             return {
               key: "root-logo",
               to: "/",
+              // Use replace prop when on root with search params to not add to history stack
+              replace: hasSearchParams && isRoot ? true : undefined,
               props: {
                 style: {
                   height: "2.8rem",
@@ -558,6 +566,11 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                       transition: "0.25s transform ease-out",
                       transformStyle: "preserve-3d",
                       svg: { display: "block" },
+                      "@media(hover: hover)": {
+                        "&:hover": {
+                          animation: "none",
+                        },
+                      },
                     })}
                   >
                     {logo}


### PR DESCRIPTION
Clicking on the logo to get back to a fresh state of the home is pretty standard on the web. I catch myself trying that all the time on camp by force of habit, so this will ensure that works.

(same motivation for #105, btw)