### PR TITLE
Activate debounces by adding wait time

### DIFF
--- a/apps/nouns-camp/src/components/browse-accounts-screen.jsx
+++ b/apps/nouns-camp/src/components/browse-accounts-screen.jsx
@@ -427,7 +427,7 @@ const BrowseAccountsScreen = () => {
       },
       { replace: true },
     );
-  });
+  }, 500);
 
   useDelegatesFetch({ includeZeroVotingPower: true, includeVotes: true });
 

--- a/apps/nouns-camp/src/components/browse-candidates-screen.jsx
+++ b/apps/nouns-camp/src/components/browse-candidates-screen.jsx
@@ -344,7 +344,7 @@ const BrowseCandidatesScreen = ({ candidateType = "proposal" }) => {
       },
       { replace: true },
     );
-  });
+  }, 500);
 
   const selectedFilters = (() => {
     const toggledFilters = [];

--- a/apps/nouns-camp/src/components/browse-proposals-screen.jsx
+++ b/apps/nouns-camp/src/components/browse-proposals-screen.jsx
@@ -386,7 +386,7 @@ const BrowseProposalsScreen = () => {
       },
       { replace: true },
     );
-  });
+  }, 500);
 
   const subgraphFetch = useSubgraphFetch();
 

--- a/apps/nouns-camp/src/components/landing-screen.jsx
+++ b/apps/nouns-camp/src/components/landing-screen.jsx
@@ -450,7 +450,7 @@ const BrowseScreen = () => {
       },
       { replace: true },
     );
-  });
+  }, 500);
 
   const defaultTabKey = isDesktopLayout ? "digest" : "activity";
 


### PR DESCRIPTION
The default debounce time from "use-debounce" seems to be 0, so you're probably hammering the APIs more than needed when the user is filling search fields.

I've set it to 500ms